### PR TITLE
feat: add script to prepare database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ yarn-error.log*
 
 # VSCode extensions
 .VSCodeCounter
-public/workbox-6b19f60b.js.map
-public/workbox-6b19f60b.js
+public/workbox-*.js.map
+public/workbox-*.js
 public/sw.js.map
 public/sw.js

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
-  "name": "nextjs",
-  "version": "0.1.0",
+  "name": "staticshield",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "yarn minify && next build",
+    "build": "yarn prepare-db && yarn minify && next build",
     "start": "next start",
     "minify": "npx parcel build packages/script.js --dist-dir public",
     "format": "npx prettier --write \"**/*.{js,ts,jsx,tsx,json,css,md,html}\"",
     "lint": "next lint",
+    "prepare-db": "node scripts/prepare-db",
     "generate-pwa-assets": "cd ./public/icons/ && npx pwa-asset-generator ../staticshield-rounded.png -m ../manifest.json -d -q 100 -u -f -o false"
   },
   "dependencies": {

--- a/scripts/prepare-db.js
+++ b/scripts/prepare-db.js
@@ -1,0 +1,46 @@
+require('dotenv').config({ path: '.env.local' });
+const assert = require('assert');
+const fetch = require('node-fetch');
+const { HARPERDB_KEY, HARPERDB_URL } = process.env;
+
+assert(HARPERDB_KEY, 'HARPERDB_KEY is required');
+assert(HARPERDB_URL, 'HARPERDB_URL is required');
+
+const SITE_SCHEMA = 'site_schema';
+const SITES_TABLE = 'sites';
+
+const runOperation = (body) =>
+  fetch(HARPERDB_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${HARPERDB_KEY}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+// The minimum amount of operations needed
+async function prepareDatabase() {
+  await runOperation({
+    operation: 'create_schema',
+    schema: SITE_SCHEMA,
+  });
+
+  await runOperation({
+    operation: 'create_table',
+    schema: SITE_SCHEMA,
+    table: SITES_TABLE,
+    hash_attribute: 'id',
+  });
+
+  await runOperation({
+    operation: 'create_attribute',
+    schema: SITE_SCHEMA,
+    table: SITES_TABLE,
+    attribute: 'user_id',
+  });
+
+  console.log('Database prepared');
+}
+
+prepareDatabase();


### PR DESCRIPTION
During my changes to host my own instance of the project, I created this script and I think it could be part of the build process.

HarperDB is a "hybrid" SQL/NoSQL database, so we only need a schema, a table and two attributes (`id` and `user_id`) to prevent any errors when querying the database. All of the other fields can be created when adding data.

Let me know if you think we should put the script as part of the self-hosting guide which I'm working on instead. From my perspective, it works fine too, just requires a manual step instead.

This approach of running the `prepare-db` script during each build is harmless, the database just stays as it is.